### PR TITLE
Fix variance row filtering and add regression test

### DIFF
--- a/hedge.py
+++ b/hedge.py
@@ -94,7 +94,7 @@ def _filter_no_variance_rows(
 ) -> Tuple[npt.NDArray[np.float64], List[str]]:
     index: int = 0
     while index < len(price_matrix):
-        if len(set(price_matrix[0])) == 1:
+        if len(set(price_matrix[index])) == 1:
             price_matrix = _remove_row(price_matrix, index)
             del ticker_map[index]
         else:

--- a/tests/test_hedge.py
+++ b/tests/test_hedge.py
@@ -74,6 +74,11 @@ def test_filters() -> None:
     filtered, tickers = _filter_no_variance_rows(matrix, tickers)
     assert filtered.tolist() == [[1, 2, 3]] and tickers == ["B"]
 
+    matrix = np.array([[1, 2, 3], [4, 4, 4]])
+    tickers = ["A", "B"]
+    filtered, tickers = _filter_no_variance_rows(matrix, tickers)
+    assert filtered.tolist() == [[1, 2, 3]] and tickers == ["A"]
+
     matrix = np.array([[1, 1.0, 1.05], [1, 3, 5]])
     tickers = ["A", "B"]
     filtered, tickers = _filter_low_variance_rows(matrix, tickers)


### PR DESCRIPTION
## Summary
- fix `_filter_no_variance_rows` to examine each row instead of always the first
- add regression test verifying non-leading constant price series are removed

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893d9254bac83269e3fb366c1cdfeb4