### PR TITLE
Improve HTTP error handling for price fetches

### DIFF
--- a/hedge.py
+++ b/hedge.py
@@ -37,7 +37,14 @@ def historical_prices(ticker_symbol: str) -> pd.Series:
             int(datetime_to_timestamp(datetime.now())),
         )
     )
-    df: pd.DataFrame = csvstr2df(requests.get(url).text)
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        raise RuntimeError(
+            f"Failed to fetch historical prices for {ticker_symbol}"
+        ) from exc
+    df: pd.DataFrame = csvstr2df(response.text)
     return cast(pd.Series, df["Adj Close"])
 
 

--- a/tests/test_hedge.py
+++ b/tests/test_hedge.py
@@ -43,9 +43,24 @@ def test_historical_prices(monkeypatch: pytest.MonkeyPatch) -> None:
     class DummyResponse:
         text = "Date,Adj Close\n2020-01-01,1\n2020-01-02,2\n"
 
+        def raise_for_status(self) -> None:
+            pass
+
     monkeypatch.setattr(requests, "get", lambda url: DummyResponse())
     series = historical_prices("AAPL")
     assert list(series) == [1, 2]
+
+
+def test_historical_prices_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummyResponse:
+        text = ""
+
+        def raise_for_status(self) -> None:  # pragma: no cover - test raising path
+            raise requests.HTTPError("error")
+
+    monkeypatch.setattr(requests, "get", lambda url: DummyResponse())
+    with pytest.raises(RuntimeError):
+        historical_prices("AAPL")
 
 
 def test_truncate_and_remove_row() -> None:


### PR DESCRIPTION
## Summary
- handle HTTP request errors in `historical_prices`
- test successful and failing price retrieval

## Testing
- `uv run --extra dev pre-commit run --files hedge.py tests/test_hedge.py`

------
https://chatgpt.com/codex/tasks/task_e_6893d8bcbcec8326aa9bfcc5e9e1991b