### PR TITLE
Vectorize return matrix computation

### DIFF
--- a/hedge.py
+++ b/hedge.py
@@ -19,15 +19,21 @@ MARKET_DAYS_IN_YEAR: int = 252
 
 
 def csvstr2df(string: str) -> pd.DataFrame:
+    """Convert a CSV string to a DataFrame."""
+
     file_: StringIO = StringIO(string)
     return pd.read_csv(file_, sep=",")
 
 
 def datetime_to_timestamp(dt: datetime) -> float:
+    """Return UNIX timestamp for a datetime."""
+
     return time.mktime(dt.timetuple()) + dt.microsecond / 1_000_000.0
 
 
 def historical_prices(ticker_symbol: str) -> pd.Series:
+    """Fetch adjusted closing prices from Yahoo Finance."""
+
     url: str = (
         "https://query1.finance.yahoo.com/v7/finance/download/%s?period1=%s&period2=%s"
         "&interval=1d&events=history&includeAdjustedClose=true"
@@ -42,6 +48,8 @@ def historical_prices(ticker_symbol: str) -> pd.Series:
 
 
 def _truncate_quotes(quotes: Dict[str, pd.Series]) -> Dict[str, pd.Series]:
+    """Limit each quote series to one year of data."""
+
     truncated_quotes: Dict[str, pd.Series] = {}
     for ticker in quotes:
         truncated_quotes[ticker] = cast(
@@ -52,12 +60,16 @@ def _truncate_quotes(quotes: Dict[str, pd.Series]) -> Dict[str, pd.Series]:
 
 
 def _remove_row(matrix: npt.NDArray[np.float64], row: int) -> npt.NDArray[np.float64]:
+    """Return matrix with the specified row removed."""
+
     return np.vstack((matrix[:row], matrix[row + 1 :]))
 
 
 def _filter_negative_prices(
     price_matrix: npt.NDArray[np.float64], ticker_map: List[str]
 ) -> Tuple[npt.NDArray[np.float64], List[str]]:
+    """Drop assets containing negative prices."""
+
     index: int = 0
     while index < len(price_matrix):
         if any(value < 0.0 for value in price_matrix[index]):
@@ -71,9 +83,13 @@ def _filter_negative_prices(
 def _filter_duplicate_rows(
     price_matrix: npt.NDArray[np.float64], ticker_map: List[str]
 ) -> Tuple[npt.NDArray[np.float64], List[str]]:
+    """Remove duplicate rows from the price matrix."""
+
     def rows_equal(
         row1: npt.NDArray[np.float64], row2: npt.NDArray[np.float64]
     ) -> bool:
+        """Return True if two rows are identical."""
+
         return all(item == row2[index] for index, item in enumerate(row1))
 
     index1: int = 0
@@ -92,6 +108,8 @@ def _filter_duplicate_rows(
 def _filter_no_variance_rows(
     price_matrix: npt.NDArray[np.float64], ticker_map: List[str]
 ) -> Tuple[npt.NDArray[np.float64], List[str]]:
+    """Remove rows with no price variance."""
+
     index: int = 0
     while index < len(price_matrix):
         if len(set(price_matrix[0])) == 1:
@@ -105,6 +123,8 @@ def _filter_no_variance_rows(
 def _filter_low_variance_rows(
     price_matrix: npt.NDArray[np.float64], ticker_map: List[str]
 ) -> Tuple[npt.NDArray[np.float64], List[str]]:
+    """Remove rows whose variance is below the threshold."""
+
     variance_threshold: float = 0.1
     index: int = 0
     while index < len(price_matrix):
@@ -120,6 +140,8 @@ def _filter_low_variance_rows(
 def _build_price_matrix(
     quotes: Dict[str, pd.Series], ticker: str
 ) -> Tuple[npt.NDArray[np.float64], List[str]]:
+    """Construct the price matrix and ticker map."""
+
     price_matrix: npt.NDArray[np.float64] = quotes[ticker].to_numpy().reshape(1, -1)
     ticker_map: List[str] = [ticker]
     for index, other_ticker in enumerate(quotes):
@@ -135,19 +157,17 @@ def _build_price_matrix(
 
 def _build_returns_matrix(
     price_matrix: npt.NDArray[np.float64],
-) -> List[List[float]]:
-    returns_matrix: List[List[float]] = []
-    for row in price_matrix:
-        returns: List[float] = []
-        for index in range(len(row) - 1):
-            returns.append((row[index + 1] - row[index]) / row[index])
-        returns_matrix.append(returns)
-    return returns_matrix
+) -> npt.NDArray[np.float64]:
+    """Compute matrix of period-to-period returns."""
+
+    return np.diff(price_matrix, axis=1) / price_matrix[:, :-1]
 
 
 def _minimize_portfolio_variance(
-    returns_matrix: List[List[float]],
+    returns_matrix: npt.NDArray[np.float64],
 ) -> CVXMatrix:
+    """Solve quadratic program to minimize portfolio variance."""
+
     s: npt.NDArray[np.float64] = np.cov(returns_matrix).astype(np.float64)
     n: int = len(s) - 1
     p: npt.NDArray[np.float64] = np.vstack(
@@ -174,6 +194,8 @@ def _minimize_portfolio_variance(
 
 
 def _filter_small_weights(weights: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    """Zero out near-zero weights and renormalize."""
+
     weight_threshold: float = 0.01
     for index, weight in enumerate(weights):
         if abs(weight) < weight_threshold:
@@ -187,6 +209,8 @@ def _compose_basket(
     ticker_map: List[str],
     hedged_ticker_symbol: str,
 ) -> Dict[str, float]:
+    """Create a hedging basket from optimized weights."""
+
     basket: Dict[str, float] = {}
     for index in range(int(len(weights) / 2)):
         pweight: float = float(weights[index])
@@ -200,6 +224,8 @@ def _compose_basket(
 def build_basket(
     hedged_ticker_symbol: str, basket_ticker_symbols: List[str]
 ) -> Dict[str, float]:
+    """Construct a hedging basket for the target ticker."""
+
     quotes: Dict[str, pd.Series] = {
         ticker: historical_prices(ticker)
         for ticker in set(basket_ticker_symbols + [hedged_ticker_symbol])

--- a/tests/test_hedge.py
+++ b/tests/test_hedge.py
@@ -32,6 +32,8 @@ from hedge import (
 
 
 def test_csv_and_timestamp() -> None:
+    """Parse CSV strings and convert datetimes to timestamps."""
+
     csv_data = "Adj Close\n1\n2\n"
     df = csvstr2df(csv_data)
     assert list(df["Adj Close"]) == [1, 2]
@@ -40,7 +42,11 @@ def test_csv_and_timestamp() -> None:
 
 
 def test_historical_prices(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fetch historical prices using a mocked HTTP response."""
+
     class DummyResponse:
+        """Simple container for fake response text."""
+
         text = "Date,Adj Close\n2020-01-01,1\n2020-01-02,2\n"
 
     monkeypatch.setattr(requests, "get", lambda url: DummyResponse())
@@ -49,6 +55,8 @@ def test_historical_prices(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_truncate_and_remove_row() -> None:
+    """Limit quote history and delete rows from matrices."""
+
     quotes = {"A": pd.Series(range(MARKET_DAYS_IN_YEAR + 10))}
     truncated = _truncate_quotes(quotes)
     assert len(truncated["A"]) == MARKET_DAYS_IN_YEAR
@@ -59,6 +67,8 @@ def test_truncate_and_remove_row() -> None:
 
 
 def test_filters() -> None:
+    """Apply all row-filtering helpers to matrices."""
+
     matrix = np.array([[1, 2], [-1, 2]])
     tickers = ["A", "B"]
     filtered, tickers = _filter_negative_prices(matrix, tickers)
@@ -81,6 +91,8 @@ def test_filters() -> None:
 
 
 def test_build_price_matrix_and_returns() -> None:
+    """Generate price and return matrices."""
+
     quotes = {
         "A": pd.Series([1.0, 2.0, 3.0]),
         "B": pd.Series([1.0, 3.0, 1.0]),
@@ -88,20 +100,28 @@ def test_build_price_matrix_and_returns() -> None:
     price_matrix, ticker_map = _build_price_matrix(quotes, "A")
     assert ticker_map == ["A", "B"]
     returns_matrix = _build_returns_matrix(price_matrix)
-    assert len(returns_matrix) == 2
+    expected = np.array([[1.0, 0.5], [2.0, -2.0 / 3.0]])
+    assert returns_matrix.shape == (2, 2)
+    np.testing.assert_allclose(returns_matrix, expected)
 
 
 def test_minimize_portfolio_variance(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Optimize portfolio variance using a fake solver."""
+
     def fake_qp(P, q, G, h, A, b):
+        """Return uniform weights regardless of inputs."""
+
         return {"x": [0.25, 0.25, 0.25, 0.25]}
 
     monkeypatch.setattr(cvxopt.solvers, "qp", fake_qp)  # type: ignore[attr-defined]
-    returns = [[0.1, 0.2, 0.15], [0.05, 0.1, 0.0], [0.2, 0.1, 0.15]]
+    returns = np.array([[0.1, 0.2, 0.15], [0.05, 0.1, 0.0], [0.2, 0.1, 0.15]])
     weights = _minimize_portfolio_variance(returns)
     assert len(weights) == 4
 
 
 def test_filter_small_weights_and_compose() -> None:
+    """Filter small weights and convert to basket."""
+
     weights = np.array([0.6, 0.02, 0.1, 0.28])
     filtered = _filter_small_weights(weights)
     assert pytest.approx(sum(filtered)) == 1.0
@@ -111,12 +131,16 @@ def test_filter_small_weights_and_compose() -> None:
 
 
 def test_filter_small_weights_threshold() -> None:
+    """Ensure weights below threshold are zeroed out."""
+
     weights = np.array([0.5, 0.005, 0.495, 0.0])
     filtered = _filter_small_weights(weights)
     assert filtered[1] == 0
 
 
 def test_build_basket(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Integrate helpers to build a hedging basket."""
+
     monkeypatch.setattr(
         "hedge.historical_prices",
         lambda symbol: pd.Series([1, 2]) if symbol == "AAA" else pd.Series([2, 3]),


### PR DESCRIPTION
## Summary
- compute returns matrix using NumPy vector operations instead of nested loops
- adjust portfolio variance optimization to accept the vectorized returns matrix
- expand unit tests to validate vectorized returns
- document every function with a concise one-line docstring

## Testing
- `ruff format hedge.py tests/test_hedge.py`
- `ruff check hedge.py tests/test_hedge.py`
- `pyright`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893d90091388326b84b828cf6ac3de6