### PR TITLE
Fix no-variance row filtering

### DIFF
--- a/hedge.py
+++ b/hedge.py
@@ -94,7 +94,7 @@ def _filter_no_variance_rows(
 ) -> Tuple[npt.NDArray[np.float64], List[str]]:
     index: int = 0
     while index < len(price_matrix):
-        if len(set(price_matrix[0])) == 1:
+        if len(set(price_matrix[index])) == 1:
             price_matrix = _remove_row(price_matrix, index)
             del ticker_map[index]
         else:

--- a/tests/test_hedge.py
+++ b/tests/test_hedge.py
@@ -69,10 +69,10 @@ def test_filters() -> None:
     filtered, tickers = _filter_duplicate_rows(matrix, tickers)
     assert filtered.tolist() == [[1, 2], [3, 4]] and tickers == ["A", "C"]
 
-    matrix = np.array([[1, 1, 1], [1, 2, 3]])
+    matrix = np.array([[1, 2, 3], [1, 1, 1]])
     tickers = ["A", "B"]
     filtered, tickers = _filter_no_variance_rows(matrix, tickers)
-    assert filtered.tolist() == [[1, 2, 3]] and tickers == ["B"]
+    assert filtered.tolist() == [[1, 2, 3]] and tickers == ["A"]
 
     matrix = np.array([[1, 1.0, 1.05], [1, 3, 5]])
     tickers = ["A", "B"]


### PR DESCRIPTION
## Summary
- ensure no-variance row filtering checks each row instead of always the first
- extend tests to cover filtering when the zero-variance row is not first

## Testing
- `pre-commit run --files hedge.py tests/test_hedge.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893d8b1156883268da36557a09a1e3e